### PR TITLE
Fixes to build on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ FetchContent_MakeAvailable(cmake_utils)
 FetchContent_Declare(
   verona-rt
   GIT_REPOSITORY https://github.com/microsoft/verona-rt
-  GIT_TAG f328732e0f45418433aa7055e2a2f5cb88395e09
+  GIT_TAG a4b5a71826b5e3f4e7c1a3be9e26e7219678097d
 )
 
 FetchContent_MakeAvailable_ExcludeFromAll(verona-rt)
@@ -33,7 +33,7 @@ FetchContent_MakeAvailable_ExcludeFromAll(verona-rt)
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/microsoft/trieste
-  GIT_TAG 30986102c54c356346ab6cb1e2d17f43272e0888
+  GIT_TAG 44e71e994b03ef766357167df32f148b03a97aa4
 )
 
 FetchContent_MakeAvailable_ExcludeFromAll(trieste)

--- a/vbcc/bytecode.cc
+++ b/vbcc/bytecode.cc
@@ -2,6 +2,10 @@
 
 #include "lang.h"
 
+#ifndef __cpp_lib_from_chars
+#include "from_chars.h"
+#endif
+
 namespace vbcc
 {
   using namespace vbci;
@@ -98,19 +102,22 @@ namespace vbcc
   template<typename T>
   T lit(Node node)
   {
+    #ifdef __cpp_lib_from_chars
+    using namespace std;
+    #endif
     auto view = node->location().view();
     auto first = view.data();
     auto last = first + view.size();
     T t = 0;
 
     if (node == Bin)
-      std::from_chars(first + 2, last, t, 2);
+      from_chars(first + 2, last, t, 2);
     else if (node == Oct)
-      std::from_chars(first + 2, last, t, 8);
+      from_chars(first + 2, last, t, 8);
     else if (node == Hex)
-      std::from_chars(first + 2, last, t, 16);
+      from_chars(first + 2, last, t, 16);
     else if (node == Int)
-      std::from_chars(first, last, t, 10);
+      from_chars(first, last, t, 10);
 
     return t;
   }
@@ -118,15 +125,18 @@ namespace vbcc
   template<>
   float lit<float>(Node node)
   {
+    #ifdef __cpp_lib_from_chars
+    using namespace std;
+    #endif
     auto view = node->location().view();
     auto first = view.data();
     auto last = first + view.size();
     float t = 0;
 
     if (node == Float)
-      std::from_chars(first, last, t);
+      from_chars(first, last, t);
     else if (node == HexFloat)
-      std::from_chars(first + 2, last, t);
+      from_chars(first + 2, last, t);
 
     return t;
   }
@@ -134,15 +144,18 @@ namespace vbcc
   template<>
   double lit<double>(Node node)
   {
+    #ifdef __cpp_lib_from_chars
+    using namespace std;
+    #endif
     auto view = node->location().view();
     auto first = view.data();
     auto last = first + view.size();
     double t = 0;
 
     if (node == Float)
-      std::from_chars(first, last, t);
+      from_chars(first, last, t);
     else if (node == HexFloat)
-      std::from_chars(first + 2, last, t);
+      from_chars(first + 2, last, t);
 
     return t;
   }

--- a/vbcc/from_chars.h
+++ b/vbcc/from_chars.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <system_error>
+// Apple Clang does not include from_chars, so we provide our own
+struct from_chars_result
+{
+  const char* ptr;
+  std::errc ec;
+};
+
+template<typename T>
+from_chars_result from_chars(const char* first, const char* last, T& value)
+{
+  std::string str(first, last);
+  try
+  {
+    if constexpr (std::is_same<T, float>::value)
+      value = std::stof(str);
+    else if constexpr (std::is_same<T, double>::value)
+      value = std::stod(str);
+    else if constexpr (std::is_same<T, long double>::value)
+      value = std::stold(str);
+    else
+      return {first, std::errc::invalid_argument};
+    return {last, {}};
+  }
+  catch (const std::invalid_argument&)
+  {
+    return {first, std::errc::invalid_argument};
+  }
+  catch (const std::out_of_range&)
+  {
+    return {first, std::errc::result_out_of_range};
+  }
+}
+
+template<typename T>
+from_chars_result from_chars(const char* first, const char* last, T& value, int base)
+{
+  std::string str(first, last);
+  try
+  {
+    value = std::stol(str, nullptr, base);
+    return {last, {}};
+  }
+  catch (const std::invalid_argument&)
+  {
+    return {first, std::errc::invalid_argument};
+  }
+  catch (const std::out_of_range&)
+  {
+    return {first, std::errc::result_out_of_range};
+  }
+}

--- a/vbcc/passes/statements.cc
+++ b/vbcc/passes/statements.cc
@@ -1,5 +1,9 @@
 #include "../lang.h"
 
+#ifndef __cpp_lib_from_chars
+#include "../from_chars.h"
+#endif
+
 namespace vbcc
 {
   const auto IntType =
@@ -37,20 +41,23 @@ namespace vbcc
   template<typename T>
   Node check_int(Node value)
   {
+    #ifdef __cpp_lib_from_chars
+    using namespace std;
+    #endif
     auto view = value->location().view();
     auto first = view.data();
     auto last = first + view.size();
-    std::from_chars_result r;
+    from_chars_result r;
     T t;
 
     if (value == Bin)
-      r = std::from_chars(first + 2, last, t, 2);
+      r = from_chars(first + 2, last, t, 2);
     else if (value == Oct)
-      r = std::from_chars(first + 2, last, t, 8);
+      r = from_chars(first + 2, last, t, 8);
     else if (value == Hex)
-      r = std::from_chars(first + 2, last, t, 16);
+      r = from_chars(first + 2, last, t, 16);
     else if (value == Int)
-      r = std::from_chars(first, last, t, 10);
+      r = from_chars(first, last, t, 10);
 
     if (r.ec == std::errc())
       return {};
@@ -64,16 +71,19 @@ namespace vbcc
   template<typename T>
   Node check_float(Node value)
   {
+    #ifdef __cpp_lib_from_chars
+    using namespace std;
+    #endif
     auto view = value->location().view();
     auto first = view.data();
     auto last = first + view.size();
-    std::from_chars_result r;
+    from_chars_result r;
     T t;
 
     if (value == Float)
-      r = std::from_chars(first, last, t);
+      r = from_chars(first, last, t);
     else if (value == HexFloat)
-      r = std::from_chars(first + 2, last, t);
+      r = from_chars(first + 2, last, t);
 
     if (r.ec == std::errc())
       return {};

--- a/vbci/CMakeLists.txt
+++ b/vbci/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CheckLinkerFlag)
+
 add_executable(vbci
   classes.cc
   dynlib.cc
@@ -28,9 +30,11 @@ else()
     -Wall -Wextra -Werror -Wshadow
     -flto -ffunction-sections -fdata-sections
     )
-  target_link_options(vbci PRIVATE
-    -rdynamic -flto -Wl,--gc-sections
-    )
+  target_link_options(vbci PRIVATE -rdynamic -flto)
+  check_linker_flag(CXX "-Wl,--gc-sections" LINKER_SUPPORTS_GC_SECTIONS)
+  if(LINKER_SUPPORTS_GC_SECTIONS)
+    target_link_options(vbci PRIVATE -Wl,--gc-sections)
+  endif()
 endif()
 
 target_link_libraries(vbci

--- a/vbci/dynlib.cc
+++ b/vbci/dynlib.cc
@@ -173,7 +173,6 @@ namespace vbci
     if (version.empty())
       f = dlsym(handle, name.c_str());
     else
-      f = dlvsym(handle, name.c_str(), version.c_str());
 #else
     // No symbol versioning.
     (void)version;

--- a/vbci/value.cc
+++ b/vbci/value.cc
@@ -15,6 +15,10 @@ namespace vbci
   Value::Value(int16_t i16) : i16(i16), tag(ValueType::I16) {}
   Value::Value(int32_t i32) : i32(i32), tag(ValueType::I32) {}
   Value::Value(int64_t i64) : i64(i64), tag(ValueType::I64) {}
+  #if defined(__APPLE__) && defined(__MACH__)
+  Value::Value(long ilong) : ilong(ilong), tag(ValueType::ILong) {}
+  Value::Value(unsigned long ulong) : ulong(ulong), tag(ValueType::ULong) {}
+  #endif
   Value::Value(float f32) : f32(f32), tag(ValueType::F32) {}
   Value::Value(double f64) : f64(f64), tag(ValueType::F64) {}
   Value::Value(void* ptr) : ptr(ptr), tag(ValueType::Ptr) {}

--- a/vbci/value.cc
+++ b/vbci/value.cc
@@ -2,6 +2,7 @@
 #include "cown.h"
 #include "object.h"
 #include "program.h"
+#include "platform.h"
 
 namespace vbci
 {
@@ -15,7 +16,7 @@ namespace vbci
   Value::Value(int16_t i16) : i16(i16), tag(ValueType::I16) {}
   Value::Value(int32_t i32) : i32(i32), tag(ValueType::I32) {}
   Value::Value(int64_t i64) : i64(i64), tag(ValueType::I64) {}
-  #if defined(__APPLE__) && defined(__MACH__)
+  #ifdef PLATFORM_IS_MACOSX
   Value::Value(long ilong) : ilong(ilong), tag(ValueType::ILong) {}
   Value::Value(unsigned long ulong) : ulong(ulong), tag(ValueType::ULong) {}
   #endif

--- a/vbci/value.h
+++ b/vbci/value.h
@@ -70,6 +70,10 @@ namespace vbci
     Value(int16_t i16);
     Value(int32_t i32);
     Value(int64_t i64);
+    #if defined(__APPLE__) && defined(__MACH__)
+    Value(long ilong);
+    Value(unsigned long ulong);
+    #endif
     Value(float f32);
     Value(double f64);
     Value(void* ptr);

--- a/vbci/value.h
+++ b/vbci/value.h
@@ -59,6 +59,10 @@ namespace vbci
     uint8_t readonly : 1;
 
     Value(ValueType t) : tag(t) {}
+#ifdef PLATFORM_IS_MACOSX
+    Value(long ilong);
+    Value(unsigned long ulong);
+#endif
 
   public:
     Value();
@@ -71,10 +75,6 @@ namespace vbci
     Value(int16_t i16);
     Value(int32_t i32);
     Value(int64_t i64);
-    #ifdef PLATFORM_IS_MACOSX
-    Value(long ilong);
-    Value(unsigned long ulong);
-    #endif
     Value(float f32);
     Value(double f64);
     Value(void* ptr);
@@ -470,10 +470,10 @@ namespace vbci
         case ValueType::I64:
         case ValueType::U32:
         case ValueType::U64:
-        #ifdef PLATFORM_IS_MACOSX
+#ifdef PLATFORM_IS_MACOSX
         case ValueType::ILong:
         case ValueType::ULong:
-        #endif
+#endif
           v.tag = t;
           break;
 

--- a/vbci/value.h
+++ b/vbci/value.h
@@ -2,6 +2,7 @@
 
 #include "ident.h"
 #include "types.h"
+#include "platform.h"
 
 #include <cmath>
 #include <cstring>
@@ -70,7 +71,7 @@ namespace vbci
     Value(int16_t i16);
     Value(int32_t i32);
     Value(int64_t i64);
-    #if defined(__APPLE__) && defined(__MACH__)
+    #ifdef PLATFORM_IS_MACOSX
     Value(long ilong);
     Value(unsigned long ulong);
     #endif
@@ -469,7 +470,7 @@ namespace vbci
         case ValueType::I64:
         case ValueType::U32:
         case ValueType::U64:
-        #if defined(__APPLE__) && defined(__MACH__)
+        #ifdef PLATFORM_IS_MACOSX
         case ValueType::ILong:
         case ValueType::ULong:
         #endif

--- a/vbci/value.h
+++ b/vbci/value.h
@@ -469,6 +469,10 @@ namespace vbci
         case ValueType::I64:
         case ValueType::U32:
         case ValueType::U64:
+        #if defined(__APPLE__) && defined(__MACH__)
+        case ValueType::ILong:
+        case ValueType::ULong:
+        #endif
           v.tag = t;
           break;
 


### PR DESCRIPTION
These are the changes I have had to make to build on a Mac:

- Apple Clang does not support `from_chars`, so I write my own limited version of it.
- The Apple Clang linker does not support `--gc-sections`, so I only use it if it is available
- Types `long` and `unsigned long` are not definitionally equivalent to `int64_t` and `uint64_t` so they are added as tags. This is the change I am least certain of.
- The Verona runtime used flags unsupported on ARM. This has been patched, so I point to that commit in the CMakeList

Calling `printf` via ffi is still broken (I suspect variadic arguments), so some more investigation is needed.