### PR TITLE
Make Dynlibs shared pointers

### DIFF
--- a/vbci/program.cc
+++ b/vbci/program.cc
@@ -540,12 +540,12 @@ namespace vbci
     // FFI information.
     auto num_libs = uleb(pc);
     for (size_t i = 0; i < num_libs; i++)
-      libs.push_back(strings.at(uleb(pc)));
+      libs.push_back(std::make_shared<Dynlib>(strings.at(uleb(pc))));
 
     auto num_symbols = uleb(pc);
     for (size_t i = 0; i < num_symbols; i++)
     {
-      auto& lib = libs.at(uleb(pc));
+      auto& lib = *libs.at(uleb(pc));
       auto& name = strings.at(uleb(pc));
       auto& version = strings.at(uleb(pc));
       bool vararg = uleb(pc);

--- a/vbci/program.h
+++ b/vbci/program.h
@@ -37,7 +37,7 @@ namespace vbci
     std::vector<ComplexType> complex_types;
     std::vector<Value> globals;
 
-    std::vector<Dynlib> libs;
+    std::vector<std::shared_ptr<Dynlib>> libs;
     std::vector<Symbol> symbols;
 
     ffi_type ffi_type_value;


### PR DESCRIPTION
There was a bug where the destructor of `Dynlib` would be called too early, closing the file and making the handle invalid. This PR puts the `Dynlib`s in shared pointers.