### PR TITLE
fix for fixes for macos fixes

### DIFF
--- a/vbcc/from_chars.h
+++ b/vbcc/from_chars.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../vbci/platform.h"
+
 // Apple Clang does not include from_chars, so we provide our own
 #if defined(PLATFORM_IS_MACOSX)
 


### PR DESCRIPTION
Added a missing import to find platform define. Creates a dependency between vbcc and vbci, is this something that we want to avoid?