### PR TITLE
Avoid closing dynamic libraries too early

### DIFF
--- a/vbci/program.cc
+++ b/vbci/program.cc
@@ -539,8 +539,9 @@ namespace vbci
 
     // FFI information.
     auto num_libs = uleb(pc);
+    libs.reserve(num_libs);
     for (size_t i = 0; i < num_libs; i++)
-      libs.push_back(strings.at(uleb(pc)));
+      libs.emplace_back(strings.at(uleb(pc)));
 
     auto num_symbols = uleb(pc);
     for (size_t i = 0; i < num_symbols; i++)


### PR DESCRIPTION
This PR improves on #2 and fixes a bug where external dynamic libraries would be closed before they were used. The `libs` vector reserves space for its elements to avoid destructors called due to resizing and elements are emplaced rather than pushed to avoid destructors of temporary objects.