### PR TITLE
adding examples

### DIFF
--- a/examples/vir/alloc_in_region_of_arg/alloc_in_region_of_arg.vir
+++ b/examples/vir/alloc_in_region_of_arg/alloc_in_region_of_arg.vir
@@ -1,0 +1,12 @@
+class @A 
+    @f : @B 
+
+class @B
+    @f : bool 
+
+func @main():i32 
+    $true = const bool true
+    $b1 = region rc @B($true)
+    $a1 = heap $b1 @A($b1) 
+    $ret_val = const i32 42 
+    ret $ret_val

--- a/examples/vir/frame_local/drag_from_local_to_local/drag_from_local_to_local.vir
+++ b/examples/vir/frame_local/drag_from_local_to_local/drag_from_local_to_local.vir
@@ -1,0 +1,51 @@
+lib
+  @printf = "printf"(ptr, ...): i32
+
+class @A 
+    @f1 : bool 
+
+class @B 
+    @f1 : @A
+
+func @main():i32 
+    $true = const bool true 
+
+    $a_true = new @A($true) //Initialize an A with field $true 
+
+    $b = new @B($a_true) //Initialize a B with field $a_true 
+
+    $res = call @update_b($b) //update b's field to be an $A which stores false
+
+    // Get the field value
+    $b_field_ref = ref $b @f1 
+    $b_field = load $b_field_ref 
+
+    $a_field_ref = ref $b_field @f1 
+    $a_field = load $a_field_ref
+
+    //printing to ensure the value is correct
+    $ret_val = const i32 42 
+    $fmt = const "%s\n"
+    $fmt_ptr = makeptr $fmt
+
+    cond $a_field ^true ^false 
+    ^true
+        $string_true = const "true" 
+        $ptr_true = makeptr $string_true
+        $out = ffi @printf($fmt_ptr,$ptr_true)
+        ret $ret_val
+    ^false 
+        $string_false = const "false" 
+        $ptr_false = makeptr $string_false
+        $out = ffi @printf($fmt_ptr,$ptr_false)
+        ret $ret_val        
+
+func @update_b($b : @B) : bool
+    $false = const bool false
+    $a_false = new @A($false)
+
+    $ref = ref $b @f1 
+    $old_val = store $ref $a_false //this drags $b into this frame, since older frames should not point to newer ones 
+      
+    $ret_val = const bool true 
+    ret $ret_val

--- a/examples/vir/frame_local/drag_into_real_region/drag_into_real_region.vir
+++ b/examples/vir/frame_local/drag_into_real_region/drag_into_real_region.vir
@@ -1,0 +1,13 @@
+class @A
+    @f1 : i32 
+
+class @B 
+    @f1 : @A
+
+func @main(): i32
+    $i = const i32 42
+    $a =  new @A($i)
+    $b = region rc @B($a)
+    ret $i
+
+    

--- a/examples/vir/frame_local/return_frame_local/return_frame_local.vir
+++ b/examples/vir/frame_local/return_frame_local/return_frame_local.vir
@@ -1,0 +1,40 @@
+lib
+  @printf = "printf"(ptr, ...): i32
+
+class @B
+    @f : bool 
+
+class @A 
+    @f : @B 
+
+func @main () : i32 
+    $true = const bool true 
+    $b = new @B($true)
+    $a = call @make_a($b)
+
+    $a_field_ref = ref $a @f 
+    $a_field = load $a_field_ref
+    $b_field_ref = ref $a_field @f 
+    $b_field = load $b_field_ref
+
+    $ret_val = const i32 42 
+    $fmt = const "%s\n"
+    $fmt_ptr = makeptr $fmt
+    
+    cond $b_field ^true ^false 
+    ^true
+        $string_true = const "true" 
+        $ptr_true = makeptr $string_true
+        $out = ffi @printf($fmt_ptr,$ptr_true)
+        ret $ret_val
+    ^false 
+        $string_false = const "false" 
+        $ptr_false = makeptr $string_false
+        $out = ffi @printf($fmt_ptr,$ptr_false)
+        ret $ret_val 
+
+
+func @make_a ($b : @B) : @A 
+    $ret_a = new @A($b)
+    ret $ret_a
+

--- a/examples/vir/frame_local/update_value_in_frame_local/update_value_in_frame_local.vir
+++ b/examples/vir/frame_local/update_value_in_frame_local/update_value_in_frame_local.vir
@@ -1,0 +1,39 @@
+lib
+  @printf = "printf"(ptr, ...): i32
+
+class @A 
+    @f1 : bool 
+
+func @main():i32 
+    $true = const bool true 
+
+    $a = new @A($true)
+  
+    $res = call @foo($a)
+
+    $ref_2 = ref $a @f1
+    $val_a = load $ref_2
+
+    $fmt = const "%s\n"
+    $fmt_ptr = makeptr $fmt
+
+    cond $val_a ^true ^false 
+    ^true
+        $string_true = const "true" 
+        $ptr_true = makeptr $string_true
+        $out = ffi @printf($fmt_ptr,$ptr_true)
+        $ret_val = const i32 42 
+        ret $ret_val
+    ^false 
+        $string_false = const "false" 
+        $ptr_false = makeptr $string_false
+        $out = ffi @printf($fmt_ptr,$ptr_false)
+        $ret_val = const i32 42 
+        ret $ret_val        
+
+func @foo($a : @A) : bool
+      $false = const bool false
+      $ref_1 = ref $a @f1
+      $old_val = store $ref_1 $false
+      $ret_val = const bool true 
+      ret $ret_val


### PR DESCRIPTION
Adds some examples, mostly for frame local allocation, but also one for creating an object in the same region as one of the arguments passed to object initialization 