### PR TITLE
Fixes to ref counting in drag

### DIFF
--- a/vbci/location.cc
+++ b/vbci/location.cc
@@ -20,9 +20,9 @@ namespace vbci
 
     while (!wl.empty())
     {
-      h = wl.back();
+      Header* next_h = wl.back();
       wl.pop_back();
-      auto find = rc_map.find(h);
+      auto find = rc_map.find(next_h);
 
       if (find != rc_map.end())
       {
@@ -31,7 +31,7 @@ namespace vbci
         continue;
       }
 
-      auto loc = h->location();
+      auto loc = next_h->location();
 
       if (loc::is_immutable(loc))
         continue;
@@ -50,12 +50,12 @@ namespace vbci
           continue;
 
         // Initial internal RC count is 1.
-        rc_map[h] = 1;
+        rc_map[next_h] = 1;
 
-        if (h->is_array())
-          static_cast<Array*>(h)->trace(wl);
+        if (next_h->is_array())
+          static_cast<Array*>(next_h)->trace(wl);
         else
-          static_cast<Object*>(h)->trace(wl);
+          static_cast<Object*>(next_h)->trace(wl);
       }
       else
       {

--- a/vbci/location.cc
+++ b/vbci/location.cc
@@ -81,11 +81,16 @@ namespace vbci
       }
     }
 
-    // Reparent regions if r is not frame-local.
+    // Assign parent to regions if r is not frame-local.
     if (frame == loc::None)
     {
       for (auto& hr : regions)
+      {
         hr->set_parent(r);
+        // Decrease stack rc for this region, as a frame local entry point is
+        // now in r.
+        hr->stack_dec();
+      }
     }
 
     // Move objects and arrays to the new region.


### PR DESCRIPTION
This makes sure that the entry edge we decrement internal rc by is actually the one from the initial entry rather than a subtraction from an arbitrary object in the rc_map, and decreases the stack rc for a region being parented by the drag