### PR TITLE
Updating drag to consider 1 reference to previous location 

### DIFF
--- a/examples/vir/frame_local/cown_drag/cown_drag.vir
+++ b/examples/vir/frame_local/cown_drag/cown_drag.vir
@@ -1,0 +1,42 @@
+type @A_or_B = @A | @B 
+
+class @closure_a 
+    @f : @A_or_B
+    @apply @closure_a_apply
+
+class @A
+    @f : @B
+
+class @B
+    @f : bool
+
+func @closure_a_apply($self : @closure_a) : @A_or_B
+    $field_ref = ref $self @f
+    $field = load $field_ref 
+
+    ret $field
+
+
+func @behavior1 ($cown1 : ref @A_or_B) : @A_or_B
+    $a1 = load $cown1 
+    $false = const bool false 
+    $b = heap $a1 @B($false)
+    $a2 = new @A($b)
+    $old = store $cown1 $a2 
+    $new = load $cown1 
+    $b2 = region rc @B($false)
+    $extra = store $cown1 $b2
+    ret $new
+
+    
+func @main() : i32 
+    $true = const bool true 
+    $b = region rc @B($true)
+    $closure_a = heap $b @closure_a($b)
+    $closure_a_apply = lookup $closure_a @apply
+    drop $b
+    $cown1 = when $closure_a_apply($closure_a) : @A_or_B
+    $cown2 = when @behavior1($cown1) : @A_or_B
+    
+    $ret_val = const i32 42 
+    ret $ret_val

--- a/vbci/cown.h
+++ b/vbci/cown.h
@@ -93,15 +93,20 @@ namespace vbci
           nr = Region::create(RegionType::RegionRC);
           nr->set_parent();
 
-          auto drag_result = drag_allocation(nr, next.get_header(), prev_loc);
-          if (!drag_result.first)
+          // if ploc is a region, must be not frame local
+          if (loc::is_region(prev_loc))
+          {
+            loc::to_region(prev_loc)->clear_parent();
+            unparent_prev = false;
+          }
+
+          if (!drag_allocation(nr, next.get_header()))
           {
             next = Value(Error::BadStore);
             nr->free_region();
           }
           else
           {
-            unparent_prev = drag_result.second;
             next_loc = next.location();
           }
         }
@@ -126,9 +131,8 @@ namespace vbci
       // Clear prev region parent if it's different from next.
       if (loc::is_region(prev_loc) && (prev_loc != next_loc))
       {
-        loc::to_region(prev_loc)->clear_parent();
-        if (!unparent_prev)
-          loc::to_region(prev_loc)->set_parent(nr);
+        if (unparent_prev)
+          loc::to_region(prev_loc)->clear_parent();
       }
       return prev;
     }

--- a/vbci/location.cc
+++ b/vbci/location.cc
@@ -6,10 +6,9 @@
 
 namespace vbci
 {
-  std::pair<bool, bool> drag_allocation(Region* r, Header* h, Location ploc)
+  bool drag_allocation(Region* r, Header* h)
   {
     auto& program = Program::get();
-    bool pr_refd = false;
     Location frame = loc::None;
 
     if (r->is_frame_local())
@@ -40,7 +39,7 @@ namespace vbci
 
       // No region, even a frame-local one, can point to the stack.
       if (loc::is_stack(loc))
-        return std::pair(false, false);
+        return false;
 
       auto hr = loc::to_region(loc);
 
@@ -68,30 +67,18 @@ namespace vbci
         // If r is not frame-local, it can't point to a region that already has
         // a parent, even if that parent is r (to preserve single entry point).
         if ((frame == loc::None) && hr->has_parent())
-        {
-          // if hr is the previous region, then as long as there is only one
-          // reference into hr from frame locals we are dragging into r, it's
-          // ok. (this reference will replace the old one from r still leaving
-          // only one entry point to hr)
-          if (loc::is_region(ploc) && loc::to_region(ploc) == hr)
-          {
-            if (pr_refd >= 1)
-              return std::pair(false, false);
-            pr_refd += 1;
-          }
-          else
-            return std::pair(false, false);
-        }
+          return false;
+
         // If hr is already an ancestor of r, we can't drag the allocation, or
         // we'll create a region cycle.
         if (hr->is_ancestor_of(r))
-          return std::pair(false, false);
+          return false;
 
         // If r is not frame-local, it can't have multiple entry points to this
         // region.
         auto [it, ok] = regions.insert(hr);
         if ((frame == loc::None) && !ok)
-          return std::pair(false, false);
+          return false;
       }
     }
 
@@ -100,9 +87,7 @@ namespace vbci
     {
       for (auto& hr : regions)
       {
-        if (!loc::is_region(ploc) || loc::to_region(ploc) != hr)
-          hr->set_parent(r);
-
+        hr->set_parent(r);
         // Decrease stack rc for this region, as a frame local entry point is
         // now in r.
         hr->stack_dec();
@@ -123,7 +108,7 @@ namespace vbci
       hh->move_region(r);
     }
 
-    return std::pair(true, !pr_refd);
+    return true;
     ;
   }
 }

--- a/vbci/location.h
+++ b/vbci/location.h
@@ -64,5 +64,5 @@ namespace vbci
     }
   }
 
-  std::pair<bool,bool> drag_allocation(Region* r, Header* h, Location pr);
+  bool drag_allocation(Region* r, Header* h);
 }

--- a/vbci/region.h
+++ b/vbci/region.h
@@ -109,7 +109,6 @@ namespace vbci
     void set_parent()
     {
       assert(!has_parent());
-      assert(stack_rc > 0);
       parent = loc::Immutable;
     }
 

--- a/vbci/thread.cc
+++ b/vbci/thread.cc
@@ -885,7 +885,7 @@ namespace vbci
         // Drag the frame-local allocation to the previous frame.
         auto& prev_frame = frames.at(frames.size() - 2);
 
-        if (!drag_allocation(&prev_frame.region, ret.get_header(),loc::None).first)
+        if (!drag_allocation(&prev_frame.region, ret.get_header()))
         {
           ret = Value(Error::BadStackEscape);
           condition = Condition::Throw;
@@ -896,7 +896,7 @@ namespace vbci
         // Drag the frame-local allocation to a fresh region.
         auto r = Region::create(RegionType::RegionRC);
 
-        if (!drag_allocation(r, ret.get_header(),loc::None).first)
+        if (!drag_allocation(r, ret.get_header()))
         {
           ret = Value(Error::BadStackEscape);
           condition = Condition::Throw;


### PR DESCRIPTION
For non-cown references: this allows programs where an object "a" in region A originally had a reference to an object "b" in region B, which is updated to a reference to a frame local object "c" which (deeply) has exactly one reference to an object in region B. This will drag "c" into region A (along with any frame local objects "c" references). This is ok because the reference from "a" to "b" will no longer be there, so we still only have a total of one non-stack reference to region B.

If instead we are updating a cown reference to something frame local, then this allows the drag of frame locals into a new region as long as there is at most one reference to the previous real region that the cown referenced, re-parenting the previous region (which used to have the cown as parent) with the newly created region.
