### PR TITLE
Add checks to avoid crashing during fuzzing

### DIFF
--- a/vbcc/bitset.cc
+++ b/vbcc/bitset.cc
@@ -34,6 +34,11 @@ namespace vbcc
     return true;
   }
 
+  bool Bitset::unsized() const
+  {
+    return bits.empty();
+  }
+
   void Bitset::resize(size_t size)
   {
     bits.resize(idx(size - 1) + 1);

--- a/vbcc/bitset.h
+++ b/vbcc/bitset.h
@@ -21,6 +21,7 @@ namespace vbcc
 
     operator bool() const;
     bool empty() const;
+    bool unsized() const;
 
     void resize(size_t size);
     bool test(size_t i) const;

--- a/vbcc/bytecode.cc
+++ b/vbcc/bytecode.cc
@@ -225,10 +225,12 @@ namespace vbcc
     return find->second;
   }
 
-  LabelState& FuncState::get_label(Node id)
+  std::optional<std::reference_wrapper<LabelState>> FuncState::get_label(Node id)
   {
     auto index = ST::noemit().string(id->location().view());
     auto find = label_idxs.find(index);
+    if (find == label_idxs.end())
+      return {};
     return labels.at(find->second);
   }
 
@@ -410,10 +412,12 @@ namespace vbcc
     return func_id;
   }
 
-  FuncState& Bytecode::get_func(Node id)
+  std::optional<std::reference_wrapper<FuncState>> Bytecode::get_func(Node id)
   {
     auto name = ST::di().string(id);
     auto find = func_ids.find(name);
+    if (find == func_ids.end())
+      return {};
     return functions.at(find->second);
   }
 

--- a/vbcc/bytecode.h
+++ b/vbcc/bytecode.h
@@ -57,7 +57,7 @@ namespace vbcc
     FuncState(Node func) : func(func) {}
 
     std::optional<size_t> get_label_id(Node id);
-    LabelState& get_label(Node id);
+    std::optional<std::reference_wrapper<LabelState>> get_label(Node id);
     bool add_label(Node id);
 
     std::optional<size_t> get_register_id(Node id);
@@ -117,7 +117,7 @@ namespace vbcc
     void add_method(Node method);
 
     std::optional<size_t> get_func_id(Node id);
-    FuncState& get_func(Node id);
+    std::optional<std::reference_wrapper<FuncState>> get_func(Node id);
     FuncState& add_func(Node func);
 
     std::optional<size_t> get_symbol_id(Node id);

--- a/vbcc/passes/assignids.cc
+++ b/vbcc/passes/assignids.cc
@@ -120,7 +120,7 @@ namespace vbcc
           if (type_id)
           {
             state->error = true;
-            return err(_(Type) / TypeId, "class shadows type alias name");
+            return err(_(Class) / ClassId, "class shadows type alias name");
           }
 
           if (!state->add_class(_(Class)))
@@ -216,7 +216,7 @@ namespace vbcc
         // Define all destination registers.
         Def[Body] >> [state](Match& _) -> Node {
           auto dst = _(Body) / LocalId;
-          state->get_func(dst->parent(Func) / FunctionId).add_register(dst);
+          state->get_func(dst->parent(Func) / FunctionId)->get().add_register(dst);
           return NoChange;
         },
       }};
@@ -231,6 +231,10 @@ namespace vbcc
 
       for (auto& func_state : state->functions)
       {
+        if (func_state.register_names.size() == 0) {
+          top << err(func_state.func, "function has no registers");
+          break;
+        }
         for (auto& label : func_state.labels)
           label.resize(func_state.register_names.size());
       }

--- a/vbcc/passes/liveness.cc
+++ b/vbcc/passes/liveness.cc
@@ -15,8 +15,14 @@ namespace vbcc
       Bitset vars;
 
       auto def = [&](Node& id) {
-        auto r = *func->get_register_id(id);
-        std::tuple<bool, std::string> def_ret = label->def(r, id, vars.test(r));
+        auto r = func->get_register_id(id);
+        if (!r)
+        {
+          state->error = true;
+          id->parent()->replace(id, err(clone(id), "def of unknown register"));
+          return;
+        }
+        std::tuple<bool, std::string> def_ret = label->def(*r, id, vars.test(*r));
 
         if (!std::get<0>(def_ret))
         {
@@ -26,7 +32,14 @@ namespace vbcc
       };
 
       auto use = [&](Node& id) {
-        if (!label->use(*func->get_register_id(id), id))
+        auto r = func->get_register_id(id);
+        if (!r)
+        {
+          state->error = true;
+          id->parent()->replace(id, err(clone(id), "use of unknown register"));
+          return;
+        }
+        if (!label->use(*r, id))
         {
           state->error = true;
           id->parent()->replace(id, err(clone(id), "use of dead register"));
@@ -34,7 +47,14 @@ namespace vbcc
       };
 
       auto kill = [&](Node& id) {
-        if (!label->kill(*func->get_register_id(id)))
+        auto r = func->get_register_id(id);
+        if (!r)
+        {
+          state->error = true;
+          id->parent()->replace(id, err(clone(id), "kill of unknown register"));
+          return;
+        }
+        if (!label->kill(*r))
         {
           state->error = true;
           id->parent()->replace(id, err(clone(id), "use of dead register"));
@@ -45,16 +65,48 @@ namespace vbcc
         [&](auto node) {
           if (node == Func)
           {
-            func = &state->get_func(node / FunctionId);
+            auto func_opt = state->get_func(node / FunctionId);
+            if (!func_opt)
+              return false;
+
+            func = &func_opt->get();
+
+            if (func->register_names.empty())
+              return false;
+
             label = nullptr;
             vars.resize(func->register_names.size());
 
             for (auto var : *(node / Vars))
-              vars.set(*func->get_register_id(var));
+            {
+              auto r = func->get_register_id(var);
+              if (!r)
+              {
+                state->error = true;
+                (node / Vars)->replace(var, err(clone(var), "use of unknown register"));
+                return false;
+              }
+              vars.set(*r);
+            }
           }
           else if (node == Label)
           {
-            label = &func->get_label(node / LabelId);
+            auto label_opt = func->get_label(node / LabelId);
+            if (!label_opt)
+            {
+              state->error = true;
+              node->replace(
+                node / LabelId, err(clone(node / LabelId), "liveness of unknown label"));
+              return false;
+            }
+            label = &label_opt->get();
+            if (label->defd.unsized())
+            {
+              state->error = true;
+              node->replace(
+                node / LabelId, err(clone(node / LabelId), "label was never resized"));
+              return false;
+            }
           }
           else if (node == Move)
           {
@@ -169,12 +221,34 @@ namespace vbcc
       top->traverse([&](auto node) {
         if (node == Func)
         {
+          if ((node / Labels)->empty())
+            return false;
+
           auto target = (node / Labels)->front() / LabelId;
-          auto& func_state = state->get_func(node / FunctionId);
+          auto func_opt = state->get_func(node / FunctionId);
+          if (!func_opt)
+          {
+            state->error = true;
+            node->replace(
+              node / FunctionId, err(clone(node / FunctionId), "liveness of unknown function"));
+            return false;
+          }
+
+          auto& func_state = func_opt->get();
           auto vars = Bitset(func_state.register_names.size());
 
           for (auto var : *(node / Vars))
-            vars.set(*func_state.get_register_id(var));
+          {
+            auto r = func_state.get_register_id(var);
+            if (!r)
+            {
+              state->error = true;
+              (node / Vars)->replace(
+                var, err(clone(var), "set of unknown register"));
+              return false;
+            }
+            vars.set(*r);
+          }
 
           // Backward data-flow.
           std::queue<size_t> wl;
@@ -271,7 +345,21 @@ namespace vbcc
           }
 
           // Check that everything is defined.
-          auto& label = func_state.get_label(target);
+          auto label_opt = func_state.get_label(target);
+
+          if (!label_opt)
+          {
+            state->error = true;
+            node << err(
+              clone(target), "function entry label does not exist");
+            return false;
+          }
+
+          auto& label = label_opt->get();
+
+          if (label.defd.unsized())
+            return false; // Probably currently fuzzing
+
           auto params = Bitset(func_state.register_names.size());
 
           for (auto param : *(node / Params))

--- a/vbcc/passes/validids.cc
+++ b/vbcc/passes/validids.cc
@@ -17,6 +17,13 @@ namespace vbcc
           auto primitive = _(Primitive);
           auto type = _(Type);
           auto type_id = state->typ(type);
+
+          if (type_id < state->classes.size() + NumPrimitiveClasses)
+          {
+            state->error = true;
+            return err(type, "invalid primitive type id");
+          }
+
           auto idx = type_id - (state->classes.size() + NumPrimitiveClasses);
 
           if (state->complex_primitives.size() <= idx)
@@ -143,9 +150,9 @@ namespace vbcc
 
         T(Call)[Call] >> [state](Match& _) -> Node {
           auto call = _(Call);
-          auto& func_state = state->get_func(call / FunctionId);
+          auto func_state = state->get_func(call / FunctionId);
 
-          if ((call / Args)->size() != func_state.params)
+          if ((call / Args)->size() != func_state->get().params)
           {
             state->error = true;
             return err(call / Args, "wrong number of arguments");
@@ -199,9 +206,15 @@ namespace vbcc
         // Check that all labels in a function are defined.
         T(LabelId)[LabelId] >> [state](Match& _) -> Node {
           auto label = _(LabelId);
-          auto& func_state = state->get_func(label->parent(Func) / FunctionId);
 
-          if (!func_state.get_label_id(label))
+          auto func_state = state->get_func(label->parent(Func) / FunctionId);
+          if (!func_state)
+          {
+            state->error = true;
+            return err(label, "parent function is undefined");
+          }
+
+          if (!func_state->get().get_label_id(label))
           {
             state->error = true;
             return err(label, "undefined label");
@@ -213,9 +226,15 @@ namespace vbcc
         // Check that all registers in a function are defined.
         T(LocalId)[LocalId] >> [state](Match& _) -> Node {
           auto id = _(LocalId);
-          auto& func_state = state->get_func(id->parent(Func) / FunctionId);
 
-          if (!func_state.get_register_id(id))
+          auto func_state = state->get_func(id->parent(Func) / FunctionId);
+          if (!func_state)
+          {
+            state->error = true;
+            return err(id, "parent function is undefined");
+          }
+
+          if (!func_state->get().get_register_id(id))
           {
             state->error = true;
             return err(id, "undefined register");


### PR DESCRIPTION
This PR adds error handling so that fuzzing doesn't crash. At least the change on line 88 of assignids is a bug fix, but most changes are checking sizes and lookups from the `Bytecode` object before using them. I'm assuming that these are not initialised properly when starting from the middle of the pipeline, but that they are handled correctly during regular compilation. I'm not that fond of the `std::reference_wrapper`, but apparently that is the only way to put a "reference" in an optional (c++26 may change that).

(Trieste aside: I wonder if it would make sense to have a special callback for passes that is only called before fuzzing and that could initialize things like external state)