### PR TITLE
Fix partial application with qualified function names

### DIFF
--- a/vc/lang.h
+++ b/vc/lang.h
@@ -127,7 +127,8 @@ namespace vc
       Tuple,
       ArrayLit,
       Typetest,
-      ExprSeq);
+      ExprSeq,
+      DontCare);
 
   inline const auto wfType =
     TypeName | Union | Isect | TupleType | FuncType | TypeVar | TypeSelf;


### PR DESCRIPTION
## Problem

`(qualified::func _)` failed with "Expected an expression" in the application pass. This meant patterns like `(test::test_bar_1 _)` for partial application of qualified function names didn't work.

## Root Cause

`DontCare` was not in `ValuePat`, so when the application pass tried to match `FuncName DontCare`, no rule applied — `DontCare` wasn't recognized as a value for the "Prefix function with RHS value" rule.

## Fix

Add `DontCare` to `ValuePat` in `vc/lang.h`. This lets `FuncName DontCare` match the existing prefix-function rule, producing a `Call` with `DontCare` in its `Args`, which the existing `partial_apply` logic then converts into a lambda.

## Testing

All 1068 tests pass. `~/dev/test` now compiles and runs successfully.